### PR TITLE
Add 📝 as supported emoji for note admonition

### DIFF
--- a/src/plugins/CalloutTransformer.ts
+++ b/src/plugins/CalloutTransformer.ts
@@ -105,6 +105,7 @@ type CalloutIcon =
 
 const calloutsToAdmonitions = {
   /* prettier-ignore */ "ℹ️": "note",
+  "📝": "note",
   "💡": "tip",
   "❗": "info",
   "⚠️": "caution",


### PR DESCRIPTION
For someone writing documentation and wanting to create an admonition, the most logical option is the note emoji, which is currently unsupported by docu-notion.

As I see it there are two options:

1. Admonish documentation writers to always use ℹ️ for notes
2. Add support for 📝 as an accepted way of creating note admonitions

This PR does the latter, though I could see an argument for the former.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/docu-notion/43)
<!-- Reviewable:end -->
