### PR TITLE
Correct the typos  in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, docu-notion expects that each page has only one of the following: sub
 
 ## 6. Pull your pages
 
-First, determine the id of your root page by clicking "Share" and looking at the the url it gives you. E.g.
+First, determine the id of your root page by clicking "Share" and looking at the url it gives you. E.g.
 https://www.notion.so/hattonjohn/My-Docs-0456aa5842946bdbea3a4f37c97a0e5
 means that the id is "0456aa5842946PRETEND4f37c97a0e5".
 


### PR DESCRIPTION
It's a really small part, but I found a typo while reading README.

In README's # Instruction -> ## 6. Pull your pages, 'the' was written twice in the corresponding sentence.

It is a simple commit that fixes this.

I've read Leadme meticulously, but I haven't found a typo other than that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/docu-notion/62)
<!-- Reviewable:end -->
