### PR TITLE
3 -> 2 notion requests / second

### DIFF
--- a/src/pull.ts
+++ b/src/pull.ts
@@ -251,7 +251,7 @@ function writePage(page: NotionPage, finalMarkdown: string) {
 }
 
 const notionLimiter = new RateLimiter({
-  tokensPerInterval: 3,
+  tokensPerInterval: 2,
   interval: "second",
 });
 


### PR DESCRIPTION
I am running from the `main` branch, and I am constantly getting 502s. According to the notion docs, rate limit requests should be `429` (https://developers.notion.com/reference/request-limits) but I suspect that their API is not perfect, and returns 502s instead a lot of the time.

Anecdotally, someone claims that the limit is 3/requests per second. As this value is set in `docu-notion` I can imagine that due to network, randomness, having the set limit be exactly their internal limit would mean that sometimes you skirt over the edge.

https://www.reddit.com/r/Notion/comments/xfufed/how_do_you_handle_request_limits_using_notion_api/

I have found that setting it to 2 greatly reduces the 502 timeout/rate limit issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/docu-notion/80)
<!-- Reviewable:end -->
