### PR TITLE
fix: load file-type via ESM-safe shim to allow bump to ^21 (CVE-2026-31808)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^9.2.0",
         "cosmiconfig": "^8.0.0",
         "cosmiconfig-typescript-loader": "^4.3.0",
-        "file-type": "16.5.3",
+        "file-type": "^21.0.0",
         "fs-extra": "^10.1.0",
         "limiter": "^2.1.0",
         "markdown-table": "^2.0.0",
@@ -138,6 +138,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -413,10 +423,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -2647,13 +2675,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2663,13 +2690,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -3316,16 +3336,18 @@
       }
     },
     "node_modules/file-type": {
-      "version": "16.5.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
-      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
       "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
@@ -3782,6 +3804,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -4541,6 +4564,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -4893,18 +4922,6 @@
         "node": "*"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5142,6 +5159,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -5150,22 +5168,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/regenerate": {
@@ -5688,6 +5690,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -5697,6 +5700,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5823,15 +5827,15 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
       "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
+        "@tokenizer/token": "^0.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -5992,15 +5996,17 @@
       }
     },
     "node_modules/token-types": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
-      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
       "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "type": "github",
@@ -6163,6 +6169,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6207,6 +6225,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/util/node_modules/inherits": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "pull-sample-with-paths": "npm run ts -- -n $DOCU_NOTION_INTEGRATION_TOKEN -r $DOCU_NOTION_SAMPLE_ROOT_PAGE -m ./sample --img-output-path ./sample_img",
     "lint": "eslint . --ext .ts"
   },
-  "//file-type": "have to use this version before they switched to ESM, which gives a compile error related to require()",
   "//chalk@4": "also ESM related problem",
   "//note: ts-node": "really is a runtime dependency",
   "dependencies": {
@@ -29,7 +28,7 @@
     "commander": "^9.2.0",
     "cosmiconfig": "^8.0.0",
     "cosmiconfig-typescript-loader": "^4.3.0",
-    "file-type": "16.5.3",
+    "file-type": "^21.0.0",
     "fs-extra": "^10.1.0",
     "limiter": "^2.1.0",
     "markdown-table": "^2.0.0",
@@ -86,6 +85,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
   },
   "volta": {
     "node": "22.21.0"

--- a/src/fileType.ts
+++ b/src/fileType.ts
@@ -1,0 +1,24 @@
+// file-type v17+ is ESM-only. docu-notion is compiled as CommonJS
+// (see tsconfig.json "module": "commonjs"), so a static
+// `import from "file-type"` — or even `await import("file-type")` —
+// gets transformed by TypeScript into `require()`, which fails on
+// ESM-only modules. We use `new Function(...)` to construct a real
+// dynamic import that TypeScript does not transform.
+
+export type FileTypeResult = { ext: string; mime: string };
+
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const importFileType = new Function(
+  "return import('file-type')"
+) as () => Promise<{
+  fileTypeFromBuffer: (
+    buf: Uint8Array
+  ) => Promise<FileTypeResult | undefined>;
+}>;
+
+export async function detectFileType(
+  buffer: Uint8Array
+): Promise<FileTypeResult | undefined> {
+  const { fileTypeFromBuffer } = await importFileType();
+  return fileTypeFromBuffer(buffer);
+}

--- a/src/images.ts
+++ b/src/images.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs-extra";
-import FileType, { FileTypeResult } from "file-type";
+import { detectFileType, type FileTypeResult } from "./fileType";
 import { makeImagePersistencePlan } from "./MakeImagePersistencePlan";
 import { logDebug, verbose } from "./log";
 import { ListBlockChildrenResponseResult } from "notion-to-md/build/types";
@@ -158,7 +158,7 @@ async function readPrimaryImage(imageSet: ImageSet) {
   const response = await fetch(imageSet.primaryUrl);
   const arrayBuffer = await response.arrayBuffer();
   imageSet.primaryBuffer = Buffer.from(arrayBuffer);
-  imageSet.fileType = await FileType.fromBuffer(imageSet.primaryBuffer);
+  imageSet.fileType = await detectFileType(imageSet.primaryBuffer);
 }
 
 async function saveImage(imageSet: ImageSet): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes [CVE-2026-31808](https://nvd.nist.gov/vuln/detail/CVE-2026-31808) (file-type DoS via crafted ASF header, CVSS 5.3) by upgrading `file-type` from `16.5.3` to `^21.0.0`.

The existing `"//file-type"` comment in `package.json` documents why this bump was previously blocked: `file-type@17+` is ESM-only, and a static `import from "file-type"` under `tsconfig module: commonjs` gets rewritten to `require("file-type")`, which fails on ESM-only packages. Downstream consumers who add a resolution forcing `file-type` to the CVE-fixed `21.3.3` currently hit a runtime crash in `src/images.ts` because `FileType.fromBuffer` no longer exists on the v21 API.

This PR resolves the CJS↔ESM boundary without changing the project's compile target.

## Approach

Added `src/fileType.ts`, a 24-line shim that wraps `file-type`'s ESM API behind a `new Function("return import('file-type')")` trampoline. TypeScript's `commonjs` transform does not inspect strings inside `new Function(...)`, so the `import()` expression reaches Node's native dynamic import at runtime. `src/images.ts` is rewired to call `detectFileType(buffer)` from the shim instead of the old static `FileType.fromBuffer`.

The shim is quarantined to a single file with a comment explaining the rationale. If the project later migrates to ESM, the shim becomes a one-file delete plus inlining a static import in `src/images.ts`.

## Changes

- `package.json`
  - Bump `file-type` from `16.5.3` to `^21.0.0`.
  - Remove the stale `"//file-type"` workaround comment (workaround is now documented at its point of use).
  - Add `"engines": { "node": ">=20" }` — `file-type@21` requires Node 20+, so the project's floor shifts. Matches the existing `volta.node` pin.
- `src/fileType.ts` (new, 24 lines) — typed `detectFileType(buffer)` helper and local `FileTypeResult = { ext: string; mime: string }` type.
- `src/images.ts` — two-line diff: replace the static `file-type` import with one from `./fileType`, and replace the `FileType.fromBuffer(...)` call with `detectFileType(...)`. `ImageSet.fileType?: FileTypeResult` is unchanged (identifier resolves to the local re-export, same shape).

## Breaking change

Minimum Node version moves from `14+` (implicit, via `file-type@16`) to `20+` (required by `file-type@21`). The `"engines"` field makes this a loud `EBADENGINE` warning at install time rather than a silent runtime crash.

## Test plan

- [x] `npm run build` passes (vitest + tsc).
- [x] Compiled `dist/*.js` contains no `require("file-type")` — the only reference is the `new Function` string literal in `dist/fileType.js`.
- [x] `npm run pull-test-tagged` completes successfully against a live Notion workspace. Downloaded images land with correct buffer-detected extensions (no `ERR_REQUIRE_ESM`, no `fromBuffer is not a function`).

## Notes for reviewers

- **Version range:** `^21.0.0` rather than `^22.0.0`, since file-type@22 raises the Node floor to 22. `^21.0.0` satisfies the CVE fix (shipped in 21.3.3), accepts forward patch updates in the 21.x line, and keeps Node 20 in the compatibility matrix.
- **Why `new Function` rather than `await import("file-type")` directly:** under `tsc --module commonjs`, `await import("file-type")` compiles to `Promise.resolve().then(() => require("file-type"))`, which crashes on ESM-only modules. The `new Function` escape hatch is the standard, widely-used CJS→ESM bridge (see also: `tsimportlib`, `dynamic-import-function`). Inlined here to avoid adding a tiny runtime dep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/docu-notion/127)
<!-- Reviewable:end -->
