### PR TITLE
feat: Output Docusaurus v3-compatible markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ docu-notion lets you use Notion as your editor for [Docusaurus](https://docusaur
 
 Example Site: https://sillsdev.github.io/docu-notion-sample-site/
 
+# Docusaurus 3 Output
+
+docu-notion emits Docusaurus v3-compatible markdown by default.
+
+The default output changed in these ways:
+
+- Heading anchors are emitted with Docusaurus v3's MDX-comment syntax, for example `# Heading {/* #my-explicit-id */}`, instead of Docusaurus v2's `{#...}` syntax.
+- `⚠️` callouts now emit `:::warning[Caution]` instead of the deprecated `:::caution` syntax.
+- Callouts with unrecognized emojis now emit `:::note[emoji]` instead of using the emoji itself as a custom admonition keyword.
+- Named Notion callout icons that are not returned by the API as emoji are ignored and fall back to a plain `:::note` admonition.
+- docu-notion now warns when a generated page contains more than one Markdown H1, and the warning lists the H1 headings it found.
+
+If you need the previous output, pass `--docusaurus-v2`. This restores the legacy heading ID syntax, the `:::caution` output, and the raw-emoji admonition fallback.
+
+If you use `--docusaurus-v2` on Docusaurus v3, keep the `markdown.mdx1Compat.headingIds` and `markdown.mdx1Compat.admonitions` compatibility options enabled. They are on by default in Docusaurus v3, but some sites turn them off during migration.
+
+When upgrading an existing Docusaurus site to v3, it is also worth running `npx docusaurus-mdx-checker` on the site to catch MDX v3 issues in any hand-written docs or custom plugin output.
+
 # Instructions
 
 ## 1. Set up your documentation site
@@ -122,19 +140,20 @@ Usage: `docu-notion -n <token> -r <root> [options]`
 
 Options:
 
-| flag                                  | required? | description                                                                                                                                                                                                        |
-| ------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `-n, --notion-token <string>`           | required  | notion api token, which looks like `secret_3bc1b50XFYb15123RHF243x43450XFY33250XFYa343`                                                                                                                            |
-| `-r, --root-page <string>`              | required  | The 31 character ID of the page which is the root of your docs page in notion. The code will look like `9120ec9960244ead80fa2ef4bc1bba25`. This page must have a child page named 'Outline'                        |
-| `-m, --markdown-output-path <string>`   |           | Root of the hierarchy for md files. WARNING: node-pull-mdx will delete files from this directory. Note also that if it finds localized images, it will create an i18n/ directory as a sibling. (default: `./docs`) |
-| `-t, --status-tag <string>`             |           | Database pages without a Notion page property 'status' matching this will be ignored. Use '\*' to ignore status altogether. (default: `Publish`)                                                                   |
-| `--locales <codes>`                     |           | Comma-separated list of iso 639-2 codes, the same list as in docusaurus.config.js, minus the primary (i.e. 'en'). This is needed for image localization. (default: `[]`)                                             |
-| `-l, --log-level <level>`               |           | Log level (choices: `info`, `verbose`, `debug`)                                                                                                                                                                    |
-| `-i, --img-output-path <string>`        |           | Path to directory where images will be stored. If this is not included, images will be placed in the same directory as the document that uses them, which then allows for localization of screenshots.             |
-| `-p, --img-prefix-in-markdown <string>` |           | When referencing an image from markdown, prefix with this path instead of the full img-output-path. Should be used only in conjunction with --img-output-path.                                                     |
-| `--require-slugs`                       |           | If set, docu-notion will fail if any pages it would otherwise publish are missing a slug in Notion. |
+| flag                                    | required? | description                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-n, --notion-token <string>`           | required  | notion api token, which looks like `secret_3bc1b50XFYb15123RHF243x43450XFY33250XFYa343`                                                                                                                                                                                                                             |
+| `-r, --root-page <string>`              | required  | The 31 character ID of the page which is the root of your docs page in notion. The code will look like `9120ec9960244ead80fa2ef4bc1bba25`. This page must have a child page named 'Outline'                                                                                                                         |
+| `-m, --markdown-output-path <string>`   |           | Root of the hierarchy for md files. WARNING: node-pull-mdx will delete files from this directory. Note also that if it finds localized images, it will create an i18n/ directory as a sibling. (default: `./docs`)                                                                                                  |
+| `-t, --status-tag <string>`             |           | Database pages without a Notion page property 'status' matching this will be ignored. Use '\*' to ignore status altogether. (default: `Publish`)                                                                                                                                                                    |
+| `--locales <codes>`                     |           | Comma-separated list of iso 639-2 codes, the same list as in docusaurus.config.js, minus the primary (i.e. 'en'). This is needed for image localization. (default: `[]`)                                                                                                                                            |
+| `-l, --log-level <level>`               |           | Log level (choices: `info`, `verbose`, `debug`)                                                                                                                                                                                                                                                                     |
+| `-i, --img-output-path <string>`        |           | Path to directory where images will be stored. If this is not included, images will be placed in the same directory as the document that uses them, which then allows for localization of screenshots.                                                                                                              |
+| `-p, --img-prefix-in-markdown <string>` |           | When referencing an image from markdown, prefix with this path instead of the full img-output-path. Should be used only in conjunction with --img-output-path.                                                                                                                                                      |
+| `--require-slugs`                       |           | If set, docu-notion will fail if any pages it would otherwise publish are missing a slug in Notion.                                                                                                                                                                                                                 |
+| `--docusaurus-v2`                       |           | Emit Docusaurus v2-compatible markdown instead of the default Docusaurus v3-compatible output. This preserves legacy heading IDs, `:::caution`, and raw-emoji admonition keywords.                                                                                                                                  |
 | `--image-file-name-format <format>`     |           | choices:<ul><li>`default`: {page slug (if any)}.{image block ID}</li><li>`content-hash`: Use a hash of the image content.</li><li>`legacy`: Use the legacy (before v0.16) method of determining file names. Set this to maintain backward compatibility.</li></ul>All formats will use the original file extension. |
-| `-h, --help`                            |           | display help for command                              |
+| `-h, --help`                            |           | display help for command                                                                                                                                                                                                                                                                                            |
 
 # Plugins
 
@@ -142,16 +161,19 @@ If your project needs some processing that docu-notion doesn't already provide, 
 
 # Callouts ➜ Admonitions
 
-To map Notion callouts to Docusaurus admonitions, ensure the icon is for the type you want.
+To map Notion callouts to Docusaurus admonitions, ensure the icon is an emoji for the type you want.
 
 - ℹ️ ➜ note
 - 📝➜ note
 - 💡➜ tip
 - ❗➜ info
-- ⚠️➜ caution
+- ⚠️➜ warning[Caution]
 - 🔥➜ danger
+- unknown emoji ➜ note[emoji]
 
-The default admonition type, if no matching icon is found, is "note".
+If a Notion callout uses a named Notion icon instead of an emoji, docu-notion does not try to synthesize an equivalent symbol from the icon name or color. Those callouts fall back to a plain `:::note` admonition.
+
+The default admonition type, if no matching icon is found, is "note". Use `--docusaurus-v2` to keep the legacy `⚠️ ➜ caution` behavior and the old raw-emoji fallback.
 
 # Known Workarounds
 

--- a/src/latex.spec.ts
+++ b/src/latex.spec.ts
@@ -51,6 +51,7 @@ test("Latex Rendering", async () => {
       imgOutputPath: "",
       imgPrefixInMarkdown: "",
       statusTag: "",
+      docusaurusV2: false,
     },
 
     pages: pages,

--- a/src/plugins/CalloutTransformer.spec.ts
+++ b/src/plugins/CalloutTransformer.spec.ts
@@ -111,7 +111,7 @@ test("external link inside callout, bold preserved", async () => {
     } as unknown as NotionBlock,
   ]);
   expect(results.trim()).toBe(
-    `:::caution
+    `:::warning[Caution]
 
 Callouts inline [**great page**](https://github.com).
 
@@ -193,9 +193,62 @@ test("internal link inside callout, bold preserved", async () => {
     [slugTargetPage]
   );
   expect(results.trim()).toBe(
-    `:::caution
+    `:::warning[Caution]
 
 Callouts inline [**great page**](/hello-world#456) the end.
+
+:::`
+  );
+});
+
+test("unknown emoji callout falls back to note with title in docusaurus v3 mode", async () => {
+  const config = { plugins: [standardCalloutTransformer] };
+  block.callout.icon.emoji = "🧪";
+  const results = await blocksToMarkdown(config, [
+    block as unknown as NotionBlock,
+  ]);
+  expect(results.trim()).toBe(
+    `:::note[🧪]
+
+This is the callout
+
+:::`
+  );
+});
+
+test("named notion icon callout falls back to plain note in docusaurus v3 mode", async () => {
+  const config = { plugins: [standardCalloutTransformer] };
+  block.callout.icon = {
+    type: "icon",
+    icon: { name: "airplane", color: "purple" },
+  };
+  const results = await blocksToMarkdown(config, [
+    block as unknown as NotionBlock,
+  ]);
+  expect(results.trim()).toBe(
+    `:::note
+
+This is the callout
+
+:::`
+  );
+});
+
+test("docusaurus-v2 flag keeps legacy callout syntax", async () => {
+  const config = { plugins: [standardCalloutTransformer] };
+  block.callout.icon.emoji = "⚠️";
+  const results = await blocksToMarkdown(
+    config,
+    [block as unknown as NotionBlock],
+    undefined,
+    undefined,
+    undefined,
+    { docusaurusV2: true }
+  );
+  expect(results.trim()).toBe(
+    `:::caution
+
+This is the callout
 
 :::`
   );

--- a/src/plugins/CalloutTransformer.ts
+++ b/src/plugins/CalloutTransformer.ts
@@ -1,17 +1,16 @@
 import { NotionToMarkdown } from "notion-to-md";
 import { NotionBlock } from "../types";
-import { IPlugin } from "./pluginTypes";
+import { IDocuNotionContext, IPlugin } from "./pluginTypes";
 
-// In Notion, you can make a callout and change its emoji. We map 5 of these
-// to the 5 Docusaurus admonition styles.
+// In Notion, you can make a callout and change its emoji. We map common callout
+// emojis to the built-in Docusaurus admonition styles.
 // This is mostly a copy of the callout code from notion-to-md. The change is to output docusaurus
 // admonitions instead of emulating a callout with markdown > syntax.
 // Note: I haven't yet tested this with any emoji except "💡"/"tip", nor the case where the
 // callout has-children. Not even sure what that would mean, since the document I was testing
 // with has quite complex markup inside the callout, but still takes the no-children branch.
 async function notionCalloutToAdmonition(
-  notionToMarkdown: NotionToMarkdown,
-  getBlockChildren: (id: string) => Promise<NotionBlock[]>,
+  context: IDocuNotionContext,
   block: NotionBlock
 ): Promise<string> {
   // In this case typescript is not able to index the types properly, hence ignoring the error
@@ -24,7 +23,10 @@ async function notionCalloutToAdmonition(
     const annotations = content.annotations;
     let plain_text = content.plain_text;
 
-    plain_text = notionToMarkdown.annotatePlainText(plain_text, annotations);
+    plain_text = context.notionToMarkdown.annotatePlainText(
+      plain_text,
+      annotations
+    );
 
     if (content["href"]) plain_text = `[${plain_text}](${content["href"]})`;
 
@@ -34,14 +36,14 @@ async function notionCalloutToAdmonition(
   let callout_string = "";
   const { id, has_children } = block as any;
   if (!has_children) {
-    const result1 = callout(parsedData, icon);
+    const result1 = callout(parsedData, icon, context.options);
     return result1;
   }
 
-  const callout_children_object = await getBlockChildren(id);
+  const callout_children_object = await context.getBlockChildren(id);
 
   // // parse children blocks to md object
-  const callout_children = await notionToMarkdown.blocksToMarkdown(
+  const callout_children = await context.notionToMarkdown.blocksToMarkdown(
     callout_children_object
   );
 
@@ -50,7 +52,7 @@ async function notionCalloutToAdmonition(
     callout_string += `${child.parent}\n\n`;
   });
 
-  const result = callout(callout_string.trim(), icon);
+  const result = callout(callout_string.trim(), icon, context.options);
   return result;
 }
 
@@ -108,27 +110,51 @@ const calloutsToAdmonitions = {
   "📝": "note",
   "💡": "tip",
   "❗": "info",
-  "⚠️": "caution",
+  "⚠️": "warning",
   "🔥": "danger",
 };
 
+type DocusaurusOutputOptions = Pick<
+  IDocuNotionContext["options"],
+  "docusaurusV2"
+>;
+
 // This is the main change from the notion-to-md code.
-function callout(text: string, icon?: CalloutIcon) {
+function callout(
+  text: string,
+  icon: CalloutIcon,
+  options: DocusaurusOutputOptions
+) {
   let emoji: string | undefined;
   if (icon?.type === "emoji") {
     emoji = icon.emoji;
   }
+  const docusaurusV2 = options.docusaurusV2 ?? false;
   let docusaurusAdmonition = "note";
+  let admonitionTitle = "";
   if (emoji) {
+    if (docusaurusV2) {
+      docusaurusAdmonition =
+        calloutsToAdmonitions[emoji as keyof typeof calloutsToAdmonitions] ??
+        emoji;
+      if (docusaurusAdmonition === "warning") {
+        docusaurusAdmonition = "caution";
+      }
+      return `:::${docusaurusAdmonition}\n\n${text}\n\n:::\n\n`;
+    }
+
     // the keyof typeof magic persuades typescript that it really is OK to use emoji as a key into calloutsToAdmonitions
     docusaurusAdmonition =
       calloutsToAdmonitions[emoji as keyof typeof calloutsToAdmonitions] ??
-      // For Notion callouts with other emojis, pass them through using hte emoji as the name.
-      // For this to work on a Docusaurus site, it will need to define that time on the remark-admonitions options in the docusaurus.config.js.
-      // See https://github.com/elviswolcott/remark-admonitions and https://docusaurus.io/docs/using-plugins#using-presets.
-      emoji;
+      "note";
+
+    if (emoji === "⚠️") {
+      admonitionTitle = "[Caution]";
+    } else if (!(emoji in calloutsToAdmonitions)) {
+      admonitionTitle = `[${emoji}]`;
+    }
   }
-  return `:::${docusaurusAdmonition}\n\n${text}\n\n:::\n\n`;
+  return `:::${docusaurusAdmonition}${admonitionTitle}\n\n${text}\n\n:::\n\n`;
 }
 
 export const standardCalloutTransformer: IPlugin = {
@@ -137,11 +163,7 @@ export const standardCalloutTransformer: IPlugin = {
     {
       type: "callout",
       getStringFromBlock: (context, block) =>
-        notionCalloutToAdmonition(
-          context.notionToMarkdown,
-          context.getBlockChildren,
-          block
-        ),
+        notionCalloutToAdmonition(context, block),
     },
   ],
 };

--- a/src/plugins/HeadingTranformer.spec.ts
+++ b/src/plugins/HeadingTranformer.spec.ts
@@ -2,38 +2,151 @@ import { NotionBlock } from "../types";
 import { blocksToMarkdown } from "./pluginTestRun";
 import { standardHeadingTransformer } from "./HeadingTransformer";
 
+function makeHeadingBlock(
+  headingBlockId: string,
+  text: string,
+  type: "heading_1" | "heading_2" | "heading_3" = "heading_1"
+): NotionBlock {
+  return {
+    object: "block",
+    id: headingBlockId,
+    type,
+    [type]: {
+      rich_text: [
+        {
+          type: "text",
+          text: { content: text, link: null },
+          annotations: {
+            bold: false,
+            italic: false,
+            strikethrough: false,
+            underline: false,
+            code: false,
+            color: "default",
+          },
+          plain_text: text,
+          href: null,
+        },
+      ],
+      is_toggleable: false,
+      color: "default",
+    },
+  } as unknown as NotionBlock;
+}
+
+function makeCodeBlock(text: string, language = ""): NotionBlock {
+  return {
+    object: "block",
+    id: "33333333-3333-3333-3333-333333333333",
+    type: "code",
+    code: {
+      caption: [],
+      rich_text: [
+        {
+          type: "text",
+          text: { content: text, link: null },
+          annotations: {
+            bold: false,
+            italic: false,
+            strikethrough: false,
+            underline: false,
+            code: false,
+            color: "default",
+          },
+          plain_text: text,
+          href: null,
+        },
+      ],
+      language,
+    },
+  } as unknown as NotionBlock;
+}
+
 test("Adds anchor to headings", async () => {
   //setLogLevel("verbose");
   const headingBlockId = "86f746f4-1c79-4ba1-a2f6-a1d59c2f9d23";
   const config = { plugins: [standardHeadingTransformer] };
   const result = await blocksToMarkdown(config, [
-    {
-      object: "block",
-      id: headingBlockId,
-      type: "heading_1",
-      heading_1: {
-        rich_text: [
-          {
-            type: "text",
-            text: { content: "Heading One", link: null },
-            annotations: {
-              bold: false,
-              italic: false,
-              strikethrough: false,
-              underline: false,
-              code: false,
-              color: "default",
-            },
-            plain_text: "Heading One",
-            href: null,
-          },
-        ],
-        is_toggleable: false,
-        color: "default",
-      },
-    } as unknown as NotionBlock,
+    makeHeadingBlock(headingBlockId, "Heading One"),
   ]);
+  expect(result.trim()).toBe(
+    `# Heading One {/* #${headingBlockId.replaceAll("-", "")} */}`
+  );
+});
+
+test("docusaurus-v2 flag keeps legacy heading id syntax", async () => {
+  const headingBlockId = "86f746f4-1c79-4ba1-a2f6-a1d59c2f9d23";
+  const config = { plugins: [standardHeadingTransformer] };
+  const result = await blocksToMarkdown(
+    config,
+    [makeHeadingBlock(headingBlockId, "Heading One")],
+    undefined,
+    undefined,
+    undefined,
+    { docusaurusV2: true }
+  );
   expect(result.trim()).toBe(
     `# Heading One {#${headingBlockId.replaceAll("-", "")}}`
   );
+});
+
+test("warns when more than one H1 is generated for a page", async () => {
+  const consoleLogSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation(() => undefined);
+
+  try {
+    await blocksToMarkdown({ plugins: [standardHeadingTransformer] }, [
+      makeHeadingBlock("11111111-1111-1111-1111-111111111111", "Heading One"),
+      makeHeadingBlock("22222222-2222-2222-2222-222222222222", "Heading Two"),
+    ]);
+  } finally {
+    expect(
+      consoleLogSpy.mock.calls.some(call =>
+        String(call[0]).includes(
+          'contains 2 H1 headings. Docusaurus pages should have at most one H1. H1 headings: "Heading One", "Heading Two".'
+        )
+      )
+    ).toBe(true);
+    consoleLogSpy.mockRestore();
+  }
+});
+
+test("does not warn when multiple markdown-style H1 lines appear inside a code block", async () => {
+  const consoleLogSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation(() => undefined);
+
+  try {
+    await blocksToMarkdown({ plugins: [standardHeadingTransformer] }, [
+      makeCodeBlock("# Not a heading\n# Still not a heading", "markdown"),
+    ]);
+  } finally {
+    expect(
+      consoleLogSpy.mock.calls.some(call =>
+        String(call[0]).includes("H1 headings")
+      )
+    ).toBe(false);
+    consoleLogSpy.mockRestore();
+  }
+});
+
+test("does not count markdown-style H1 lines inside code blocks toward the page H1 warning", async () => {
+  const consoleLogSpy = vi
+    .spyOn(console, "log")
+    .mockImplementation(() => undefined);
+
+  try {
+    await blocksToMarkdown({ plugins: [standardHeadingTransformer] }, [
+      makeHeadingBlock("11111111-1111-1111-1111-111111111111", "Heading One"),
+      makeCodeBlock("# Not a heading", "markdown"),
+    ]);
+  } finally {
+    expect(
+      consoleLogSpy.mock.calls.some(call =>
+        String(call[0]).includes("H1 headings")
+      )
+    ).toBe(false);
+    consoleLogSpy.mockRestore();
+  }
 });

--- a/src/plugins/HeadingTransformer.ts
+++ b/src/plugins/HeadingTransformer.ts
@@ -1,27 +1,27 @@
 import { NotionToMarkdown } from "notion-to-md";
 import { NotionBlock } from "../types";
-import { IPlugin } from "./pluginTypes";
+import { IDocuNotionContext, IPlugin } from "./pluginTypes";
 import { logDebug } from "../log";
 
 // Makes links to headings work in docusaurus
 // https://github.com/sillsdev/docu-notion/issues/20
 async function headingTransformer(
-  notionToMarkdown: NotionToMarkdown,
+  context: IDocuNotionContext,
   block: NotionBlock
 ): Promise<string> {
   // First, remove the prefix we added to the heading type
   (block as any).type = block.type.replace("DN_", "");
 
-  const markdown = await notionToMarkdown.blockToMarkdown(block);
+  const markdown = await context.notionToMarkdown.blockToMarkdown(block);
 
   logDebug(
     "headingTransformer, markdown of a heading before adding id",
     markdown
   );
 
-  // To make heading links work in docusaurus, we append an id. E.g.
-  //  ### Hello World {#my-explicit-id}
-  // See https://docusaurus.io/docs/markdown-features/toc#heading-ids.
+  // To make heading links work in Docusaurus, we add a stable block-id anchor.
+  // Docusaurus v2 uses explicit heading IDs, while the v3 default can use the
+  // MDX comment syntax at the end of the heading.
 
   // For some reason, inline links come in without the dashes, so we have to strip
   // dashes here to match them.
@@ -29,7 +29,9 @@ async function headingTransformer(
   const blockIdWithoutDashes = block.id.replaceAll("-", "");
 
   // Finally, append the block id so that it can be the target of a link.
-  return `${markdown} {#${blockIdWithoutDashes}}`;
+  if (context.options.docusaurusV2)
+    return `${markdown} {#${blockIdWithoutDashes}}`;
+  return `${markdown} {/* #${blockIdWithoutDashes} */}`;
 }
 
 export const standardHeadingTransformer: IPlugin = {
@@ -53,17 +55,17 @@ export const standardHeadingTransformer: IPlugin = {
     {
       type: "DN_heading_1",
       getStringFromBlock: (context, block) =>
-        headingTransformer(context.notionToMarkdown, block),
+        headingTransformer(context, block),
     },
     {
       type: "DN_heading_2",
       getStringFromBlock: (context, block) =>
-        headingTransformer(context.notionToMarkdown, block),
+        headingTransformer(context, block),
     },
     {
       type: "DN_heading_3",
       getStringFromBlock: (context, block) =>
-        headingTransformer(context.notionToMarkdown, block),
+        headingTransformer(context, block),
     },
   ],
 };

--- a/src/plugins/internalLinks.spec.ts
+++ b/src/plugins/internalLinks.spec.ts
@@ -616,7 +616,7 @@ test("internal link inside callout", async () => {
     targetPage
   );
   expect(results.trim()).toBe(
-    `:::caution
+    `:::warning[Caution]
 
 Callouts inline [great page](/hello-world).
 

--- a/src/plugins/pluginTestRun.ts
+++ b/src/plugins/pluginTestRun.ts
@@ -6,6 +6,7 @@ import { HierarchicalNamedLayoutStrategy } from "../HierarchicalNamedLayoutStrat
 import { NotionPage } from "../NotionPage";
 import { getMarkdownFromNotionBlocks } from "../transform";
 import { IDocuNotionConfig } from "../config/configuration";
+import { DocuNotionOptions } from "../pull";
 import { NotionBlock } from "../types";
 import { convertInternalUrl } from "./internalLinks";
 import { numberChildrenIfNumberedList } from "../pull";
@@ -21,7 +22,8 @@ export async function blocksToMarkdown(
   //   - If you are passing in children, it is probably because your parent block has has_children=true.
   //     In that case, notion-to-md will make an API call... you'll need to set any validApiKey.
   children?: NotionBlock[],
-  validApiKey?: string
+  validApiKey?: string,
+  optionsOverrides?: Partial<DocuNotionOptions>
 ): Promise<string> {
   const notionClient = new Client({
     auth: validApiKey || "unused",
@@ -64,6 +66,8 @@ export async function blocksToMarkdown(
       imgOutputPath: "",
       imgPrefixInMarkdown: "",
       statusTag: "",
+      docusaurusV2: false,
+      ...optionsOverrides,
     },
     pages: pages ?? [],
     counts: {
@@ -244,7 +248,8 @@ export async function oneBlockToMarkdown(
   config: IDocuNotionConfig,
   block: Record<string, unknown>,
   targetPage?: NotionPage,
-  targetPage2?: NotionPage
+  targetPage2?: NotionPage,
+  optionsOverrides?: Partial<DocuNotionOptions>
 ): Promise<string> {
   // just in case someone expects these other properties that aren't normally relevant,
   // we merge the given block properties into an actual, full block
@@ -283,6 +288,11 @@ export async function oneBlockToMarkdown(
   return await blocksToMarkdown(
     config,
     [fullBlock as NotionBlock],
-    targetPage ? [dummyPage1, targetPage, targetPage2 ?? dummyPage2] : undefined
+    targetPage
+      ? [dummyPage1, targetPage, targetPage2 ?? dummyPage2]
+      : undefined,
+    undefined,
+    undefined,
+    optionsOverrides
   );
 }

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -43,7 +43,17 @@ export type DocuNotionOptions = {
   statusTag: string;
   requireSlugs?: boolean;
   imageFileNameFormat?: ImageFileNameFormat;
+  docusaurusV2?: boolean;
 };
+
+export function getOptionsForLogging<T extends { notionToken: string }>(
+  options: T
+): T {
+  return {
+    ...options,
+    notionToken: options.notionToken.substring(0, 10) + "...",
+  };
+}
 
 const kNotionApiVersion = "2026-03-11";
 
@@ -60,11 +70,7 @@ const counts = {
 
 export async function notionPull(options: DocuNotionOptions): Promise<void> {
   // It's helpful when troubleshooting CI secrets and environment variables to see what options actually made it to docu-notion.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  const optionsForLogging = { ...options };
-  // Just show the first few letters of the notion token, which start with "secret" anyhow.
-  optionsForLogging.notionToken =
-    optionsForLogging.notionToken.substring(0, 10) + "...";
+  const optionsForLogging = getOptionsForLogging(options);
 
   const config = await loadConfigAsync();
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,8 +2,13 @@ import * as fs from "fs-extra";
 import { Option, program } from "commander";
 import { setLogLevel } from "./log";
 
-import { notionPull } from "./pull";
+import { DocuNotionOptions, getOptionsForLogging, notionPull } from "./pull";
 import path from "path";
+
+type CliOptions = DocuNotionOptions & {
+  cssOutputDirectory: string;
+  logLevel: "info" | "verbose" | "debug";
+};
 
 export async function run(): Promise<void> {
   const pkg = require("../package.json");
@@ -62,6 +67,11 @@ export async function run(): Promise<void> {
       "If set, docu-notion will fail if any pages it would otherwise publish are missing a slug in Notion.",
       false
     )
+    .option(
+      "--docusaurus-v2",
+      "Emit Docusaurus v2-compatible markdown. By default docu-notion emits Docusaurus v3-compatible output.",
+      false
+    )
     .addOption(
       new Option(
         "--image-file-name-format <format>",
@@ -73,8 +83,9 @@ export async function run(): Promise<void> {
 
   program.showHelpAfterError();
   program.parse();
-  setLogLevel(program.opts().logLevel);
-  console.log(JSON.stringify(program.opts()));
+  const parsedOptions = program.opts() as CliOptions;
+  setLogLevel(parsedOptions.logLevel);
+  console.log(JSON.stringify(getOptionsForLogging(parsedOptions)));
 
   // copy in the this version of the css needed to make columns (and maybe other things?) work
   let pathToCss = "";
@@ -87,14 +98,14 @@ export async function run(): Promise<void> {
     pathToCss = "./src/css/docu-notion-styles.css";
   }
   // make any missing parts of the path exist
-  fs.ensureDirSync(program.opts().cssOutputDirectory);
+  fs.ensureDirSync(parsedOptions.cssOutputDirectory);
   fs.copyFileSync(
     pathToCss,
-    path.join(program.opts().cssOutputDirectory, "docu-notion-styles.css")
+    path.join(parsedOptions.cssOutputDirectory, "docu-notion-styles.css")
   );
 
   // pull and convert
-  await notionPull(program.opts()).then(() =>
+  await notionPull(parsedOptions).then(() =>
     console.log("docu-notion Finished.")
   );
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -59,6 +59,18 @@ export async function getMarkdownFromNotionBlocks(
   // simple regex-based tweaks. These are usually related to docusaurus
   const body = await doTransformsOnMarkdown(context, config, markdown);
 
+  const h1Headings = getMarkdownH1Headings(body);
+  if (h1Headings.length > 1) {
+    const pageLabel = context.pageInfo.slug || "(unknown page)";
+    warning(
+      `[docu-notion] Generated page "${pageLabel}" contains ${
+        h1Headings.length
+      } H1 headings. Docusaurus pages should have at most one H1. H1 headings: ${h1Headings
+        .map(heading => `"${heading}"`)
+        .join(", ")}.`
+    );
+  }
+
   // console.log("markdown after regex fixes", markdown);
   // console.log("body after regex", body);
 
@@ -66,6 +78,39 @@ export async function getMarkdownFromNotionBlocks(
   const imports = uniqueImports.join("\n");
   context.imports = []; // reset for next page
   return `${imports}\n${body}`;
+}
+
+function getMarkdownH1Headings(body: string): string[] {
+  const headings: string[] = [];
+  let activeFenceMarker: "```" | "~~~" | undefined;
+
+  for (const line of body.split(/\r?\n/)) {
+    const trimmedLine = line.trimStart();
+
+    if (trimmedLine.startsWith("```")) {
+      activeFenceMarker = activeFenceMarker === "```" ? undefined : "```";
+      continue;
+    }
+
+    if (trimmedLine.startsWith("~~~")) {
+      activeFenceMarker = activeFenceMarker === "~~~" ? undefined : "~~~";
+      continue;
+    }
+
+    if (activeFenceMarker || !/^#\s+/.test(line)) {
+      continue;
+    }
+
+    headings.push(
+      line
+        .replace(/^#\s+/, "")
+        .replace(/\s+\{\/\*\s*#.*?\*\/\}\s*$/, "")
+        .replace(/\s+\{#.*?\}\s*$/, "")
+        .trim()
+    );
+  }
+
+  return headings;
 }
 
 // operations on notion blocks before they are converted to markdown


### PR DESCRIPTION
------------------
Breaking change:
docu-notion now emits Docusaurus v3-compatible markdown by default.
Heading IDs now use Docusaurus v3's MDX-comment syntax instead of Docusaurus v2's {#...} syntax.
Notion ⚠️ callouts now emit :::warning[Caution] instead of the deprecated :::caution syntax, and unknown emoji callouts now fall back to :::note[emoji].
Users can opt in to the previous output with --docusaurus-v2.

------------------

Feature:
docu-notion now warns when a generated page contains more than one H1, and the warning lists the H1 headings it found.

------------------

Plugin note:
The exported type DocuNotionOptions now includes an optional docusaurusV2 flag.
Plugins and built-in transformers should read compatibility mode from context.options.docusaurusV2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/docu-notion/129)
<!-- Reviewable:end -->
